### PR TITLE
Update setup.py requirements and packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
-from setuptools import setup
+from pathlib import Path
+from setuptools import find_namespace_packages, setup
 
-
-setup(name='mmd-glm',
-    version='0.1',
-    url='https://github.com/diegoarri91/mmd-glm',
-    author='Diego M. Arribas',
-    author_email='diegoarri91@gmail.com',
-    license='MIT',
-    install_requires=['numpy', 'scipy', 'torch'],
-    packages=['mmdglm']
-      )
+setup(
+    name="mmd-glm",
+    version="0.1",
+    url="https://github.com/diegoarri91/mmd-glm",
+    author="Diego M. Arribas",
+    author_email="diegoarri91@gmail.com",
+    license="MIT",
+    install_requires=[
+        "matplotlib",
+        "numpy",
+        "scipy",
+        "torch",
+    ],
+    packages=find_namespace_packages(str(Path(__file__).parent), include=["mmdglm*"]),
+)


### PR DESCRIPTION
@diegoarri91 

Wasn't able to run the example as it couldn't import `mmdglm.convkernels` - so I've added this in to fix that.
`matplotlib` seemed to also be missing, so that has been added too.

Chose to exclude the examples folder, did this via specifying an include rather than an exclude:
```bash
# without the include
find_namespace_packages(str(Path(__file__).parent))
['examples', 'mmdglm', 'mmdglm.convkernels', 'mmdglm.glm']
# with the include
find_namespace_packages(str(Path(__file__).parent), include=["mmdglm*"])
['mmdglm', 'mmdglm.convkernels', 'mmdglm.glm']
```